### PR TITLE
fix: get ticketer uuid when coming from assetStore

### DIFF
--- a/src/components/flow/routers/ticket/TicketRouterForm.tsx
+++ b/src/components/flow/routers/ticket/TicketRouterForm.tsx
@@ -159,7 +159,7 @@ export default class TicketRouterForm extends React.Component<
       : this.props.assetStore.ticketers.endpoint.replace('ticketers', 'ticketer_queues');
 
     const url = isWenichatsType
-      ? ticketerQueuesEndpoint + `?ticketer_uuid=${ticketer.uuid}`
+      ? ticketerQueuesEndpoint + `?ticketer_uuid=${ticketer.uuid || ticketer.id}`
       : hasContext
       ? this.context.config.endpoints.topics
       : this.props.assetStore.ticketers.endpoint.replace('ticketers', 'topics');


### PR DESCRIPTION
- When there's only one Ticketer and it is WeniChats type the Ticketer comes from the `assetStore`, the Asset object doesn't have an `uuid` property and the `uuid` value is stored in the `id` attribute, so we check it as a fallback.